### PR TITLE
Feature/tests vehicles api

### DIFF
--- a/src/api/vehicles/index.ts
+++ b/src/api/vehicles/index.ts
@@ -5,7 +5,7 @@ import {
   getVehicleByIdHandler,
   updateVehicleByIdHandler,
   deleteVehicleHandler,
-  getAllActiveVehicleHandler
+  getAllAvailableVehicleHandler
 } from './vehicles.controller'
 
 const vehicleRouter = Router();
@@ -16,7 +16,7 @@ vehicleRouter.post('/', createVehicleHandler);
 // /api/users --> GET
 vehicleRouter.get('/', getAllVehicleHandler);
 
-vehicleRouter.get('/actives', getAllActiveVehicleHandler);
+vehicleRouter.get('/actives', getAllAvailableVehicleHandler);
 // /api/users/:id --> GET
 vehicleRouter.get('/:id', getVehicleByIdHandler);
 

--- a/src/api/vehicles/vehicles.controller.test.ts
+++ b/src/api/vehicles/vehicles.controller.test.ts
@@ -3,9 +3,11 @@ import app from '../../app'
 
 const request = supertest(app);
 
-describe('Vehicles controller', () => {
+//The tests are made with the data made by the seeder
 
-  describe('GET /api/vehicles', () => {
+describe('Vehicles controller /api/vehicles', () => {
+
+  describe('GET /', () => {
     test('should return a 200 response', async  () => {
       //Arrange]
       const status = 200;
@@ -14,41 +16,81 @@ describe('Vehicles controller', () => {
       //Assert
       expect(response.status).toBe(status);
     });
+
+    // test('should return a certain data', async () => {
+    //   //Arrange
+    //   const data = [
+    //     {
+    //         "id": 1,
+    //         "driverID": 3,
+    //         "vehicleTypeID": 1,
+    //         "name": "Vehiculo generico 1",
+    //         "plates": "1235486",
+    //         "isAvailable": true,
+    //         "isActive": true
+    //     },
+    //     {
+    //         "id": 2,
+    //         "driverID": 3,
+    //         "vehicleTypeID": 2,
+    //         "name": "Vehiculo generico 2",
+    //         "plates": "987456",
+    //         "isAvailable": true,
+    //         "isActive": true
+    //     },
+    //     {
+    //         "id": 3,
+    //         "driverID": 3,
+    //         "vehicleTypeID": 3,
+    //         "name": "Vehiculo generico 3",
+    //         "plates": "192846",
+    //         "isAvailable": true,
+    //         "isActive": true
+    //     }
+    // ]
+    //   //Act
+    //   const response = await request.get('/api/vehicles');
+    //   //Assert
+    //   expect(response.body).toEqual(data);
+    // });
+
   });
-  test('should return a certain data', async () => {
-    //Arrange
-    const data = [
-      {
-          "id": 1,
-          "driverID": 3,
-          "vehicleTypeID": 1,
-          "name": "Vehiculo generico 1",
-          "plates": "1235486",
-          "isAvailable": true,
-          "isActive": true
-      },
-      {
-          "id": 2,
-          "driverID": 3,
-          "vehicleTypeID": 2,
-          "name": "Vehiculo generico 2",
-          "plates": "987456",
-          "isAvailable": true,
-          "isActive": true
-      },
-      {
-          "id": 3,
-          "driverID": 3,
-          "vehicleTypeID": 3,
-          "name": "Vehiculo generico 3",
-          "plates": "192846",
-          "isAvailable": true,
-          "isActive": true
+
+  describe('PATCH /:id', () => {
+    test('Should update a vehicle to be unavailable', async () => {
+      //Arrange
+      const expectedData = {
+        id: 1,
+        driverID: 3,
+        vehicleTypeID: 1,
+        name: "Vehiculo generico 1",
+        plates: "1235486",
+        isAvailable: false,
+        isActive: true
       }
-  ]
-    //Act
-    const response = await request.get('/api/vehicles');
-    //Assert
-    expect(response.body).toEqual(data);
+      const status = 200;
+      const dataBody = {
+        isAvailable: false,
+      }
+      const id = 1;
+      //Act
+      const response = await request.patch(`/api/vehicles/${id}`).send(dataBody);
+      //Assert
+      expect(response.status).toBe(status);
+      expect(response.body).toEqual(expectedData)
+    })
+  })
+
+  describe('GET /actives' , () => {
+    test('Every vehicle return SHOULD have property isAvailable as true', async () => {
+      //Arrange
+      const status = 200;
+      //Act
+      const response = await request.get(`/api/vehicles/actives`);
+      //Assert
+      expect(response.status).toBe(status);
+      expect(response.body.every((vehicle: { isAvailable: boolean }) => vehicle.isAvailable === true)).toBe(true)
+    });
   });
+
 });

--- a/src/api/vehicles/vehicles.controller.test.ts
+++ b/src/api/vehicles/vehicles.controller.test.ts
@@ -1,0 +1,54 @@
+import supertest from 'supertest';
+import app from '../../app'
+
+const request = supertest(app);
+
+describe('Vehicles controller', () => {
+
+  describe('GET /api/vehicles', () => {
+    test('should return a 200 response', async  () => {
+      //Arrange]
+      const status = 200;
+      //Act
+      const response = await request.get('/api/vehicles');
+      //Assert
+      expect(response.status).toBe(status);
+    });
+  });
+  test('should return a certain data', async () => {
+    //Arrange
+    const data = [
+      {
+          "id": 1,
+          "driverID": 3,
+          "vehicleTypeID": 1,
+          "name": "Vehiculo generico 1",
+          "plates": "1235486",
+          "isAvailable": true,
+          "isActive": true
+      },
+      {
+          "id": 2,
+          "driverID": 3,
+          "vehicleTypeID": 2,
+          "name": "Vehiculo generico 2",
+          "plates": "987456",
+          "isAvailable": true,
+          "isActive": true
+      },
+      {
+          "id": 3,
+          "driverID": 3,
+          "vehicleTypeID": 3,
+          "name": "Vehiculo generico 3",
+          "plates": "192846",
+          "isAvailable": true,
+          "isActive": true
+      }
+  ]
+    //Act
+    const response = await request.get('/api/vehicles');
+    //Assert
+    expect(response.body).toEqual(data);
+  });
+});

--- a/src/api/vehicles/vehicles.controller.test.ts
+++ b/src/api/vehicles/vehicles.controller.test.ts
@@ -82,7 +82,7 @@ describe('Vehicles controller /api/vehicles', () => {
   })
 
   describe('GET /actives' , () => {
-    test('Every vehicle return SHOULD have property isAvailable as true', async () => {
+    test('Every vehicle returned SHOULD have property isAvailable as true', async () => {
       //Arrange
       const status = 200;
       //Act
@@ -93,4 +93,18 @@ describe('Vehicles controller /api/vehicles', () => {
     });
   });
 
+  describe('PATCH as DELETE /delete/:id', () => {
+    test('should set vehicle isActive and isAvailable to false', async () => {
+      //Arrange
+      const id = 2;
+      const valuesExpected = {
+        isAvailable: false,
+        isActive: false
+      }
+      //Act
+      const response = await request.patch(`/api/vehicles/delete/${id}`);
+      //Assert
+      expect(response.body).toEqual(expect.objectContaining(valuesExpected));
+    });
+  });
 });

--- a/src/api/vehicles/vehicles.controller.ts
+++ b/src/api/vehicles/vehicles.controller.ts
@@ -5,7 +5,7 @@ import {
   getVehicleById,
   updateVehicle,
   deleteVehicle,
-  getAllVehiclesStatus
+  getAllAvailableVehicles
 } from './vehicles.service'
 
 export async function createVehicleHandler(
@@ -28,9 +28,21 @@ export async function getAllVehicleHandler(req: Request, res: Response) {
   const vehicles = await getAllVehicles();
   return res.json(vehicles);
 }
-export async function getAllActiveVehicleHandler(req: Request, res: Response) {
-  const vehicles = await getAllVehiclesStatus();
+export async function getAllAvailableVehicleHandler(req: Request, res: Response, next: NextFunction) {
+
+  try {
+    const vehicles = await getAllAvailableVehicles();
+
+     if (vehicles.length === 0) {
+     return res.status(404).json({ message : 'There is no active vehicles, try again later'});
+    }
+
   return res.json(vehicles);
+  } catch (error) {
+    console.log(error);
+    return next(error);
+  }
+
 }
 
 export async function getVehicleByIdHandler(

--- a/src/api/vehicles/vehicles.service.ts
+++ b/src/api/vehicles/vehicles.service.ts
@@ -44,7 +44,7 @@ export async function getVehicleById(id: number) {
 }
 
 export async function deleteVehicle(id: number) {
-  const updateVehicle = await prisma.vehicles.update({
+  const deletedVehicle = await prisma.vehicles.update({
     where: {
       id,
     },
@@ -53,7 +53,7 @@ export async function deleteVehicle(id: number) {
       isAvailable: false,
     },
   })
-  return updateVehicle;
+  return deletedVehicle;
 }
 
 export async function updateVehicle(

--- a/src/api/vehicles/vehicles.service.ts
+++ b/src/api/vehicles/vehicles.service.ts
@@ -17,9 +17,12 @@ export async function getAllVehicles() {
   const vehicles = await prisma.vehicles.findMany();
   return vehicles;
 }
-export async function getAllVehiclesStatus() {
+export async function getAllAvailableVehicles() {
 
   const vehiclesByStatus = await prisma.vehicles.findMany({
+    where: {
+      isAvailable: true
+    },
     include: {
       Users:true,
       VehicleTypes: {
@@ -47,6 +50,7 @@ export async function deleteVehicle(id: number) {
     },
     data: {
       isActive: false,
+      isAvailable: false,
     },
   })
   return updateVehicle;


### PR DESCRIPTION
### Descripción
[//]: <> (Aca debe ir la descripcion del PullRequest, que es? que hace?)
Van los test para la API de vehicles, siendo testeados aquellos que no necesitarán autenticación, algunas correcciones chiquitas de los endpoints para un uso má real.

Hice test a:

- **/api/vehicles/:id** Pensando que en este cambiamos la propiedad *isAvailable* para cuando hay una reserva.
- **/api/vehicles/actives** Que traiga solo los vehículos con *isAvailable* en true.
- **/api/vehicles/delete/:id** Que comprueba que el vehículo eliminado lógicamente tenga sus propiedades _isAvailable_ y _isActive_ en false.

**NOTA**
- Para correr los test se tiene como supuesto que la base de datos ejecutó un `npx prisma migrate reset`, es decir, que est[a digamos en un estado inicial.

- Hay un test que es el de la ruta **/** pero este es getAllVehicles y solo el Admin lo podrá hacer entonces luego se puede cambiar-eliminar.


### Feeling
[//]: <> (Como te sientes con este PR? la solucion que entregas como te hace sentir?)
- [ ] 🤙 Solucion rapida
- [x] 👌 Terminado y listo
- [ ] 🤞 Espero que esto funcione, por favor revisar cuidadosamente

### Cómo probar?
[//]: <> (Pasos necesarios para probar esta funcionalidad)
Correr `npx prisma migrate reset` y ejecutar `npm run test`

### Screenshots (si es aplicable)
[//]: <> (Capturas de pantalla que ayuden a entender que hiciste en este PR)
![image](https://github.com/davidenco88/backend-cab/assets/79395978/40e04367-1782-4a7e-aad2-0b50735bfa93)

### Scope

- [ ] 🐞 Bugfix (non-breaking changes que resuelve un problema
- [ ] 💚 Mejora (non-breaking change que agrega/modifica funcionalidad a una característica existente)
- [x] ⚡️ Nueva característica/feature (non-breaking change que agrega una nueva característica)
- [ ] ⚠️ Breaking change (cambio que no es compatible con versiones anteriores y/o cambia la funcionalidad actual)
