### PR TITLE
Fix/default image set prisma

### DIFF
--- a/prisma/migrations/20230713044215_fix_default_avatar/migration.sql
+++ b/prisma/migrations/20230713044215_fix_default_avatar/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Users" ALTER COLUMN "avatar" SET DEFAULT 'https://res.cloudinary.com/dltibnft3/image/upload/v1688949117/profile-images/blank-profile-picture_wagjpu.jpg';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Users {
   name                 String
   lastname             String
   email                String          @unique
-  avatar               String          @default("https://url.zip/806f91e")
+  avatar               String          @default("https://res.cloudinary.com/dltibnft3/image/upload/v1688949117/profile-images/blank-profile-picture_wagjpu.jpg")
   isActive             Boolean         @default(false)
   password             String
   passwordResetToken   String?         @unique

--- a/src/api/users/users.service.ts
+++ b/src/api/users/users.service.ts
@@ -15,7 +15,6 @@ export async function createUser(input: CreateUser) {
       name: input.name,
       lastname: input.lastname,
       email: input.email,
-      avatar: input.avatar,
       password: hashedPassword,
       passwordResetToken: hashPasswordResetToken,
       passwordResetExpires: passwordResetExpires,

--- a/src/api/users/users.type.ts
+++ b/src/api/users/users.type.ts
@@ -6,7 +6,7 @@ export type CreateUser = {
   name: string;
   lastname: string;
   email: string;
-  avatar: string;
+  avatar?: string;
   password: string;
   rol_id: number[];
 };

--- a/src/auth/local/local.controller.ts
+++ b/src/auth/local/local.controller.ts
@@ -91,7 +91,9 @@ export async function activateHandler(req: Request, res: Response) {
 
     const profile = {
       fullName: `${user.name} ${user.lastname}`,
+      id: user.id,
       avatar: user.avatar,
+      email: user.email,
       roles: user.UserByRole.map(({ Rol }) => ({
         id: Rol.id,
         name: Rol.name,


### PR DESCRIPTION
### Descripción
[//]: <> (Aca debe ir la descripcion del PullRequest, que es? que hace?)
Va fix para que pueda setearse una imagen por default para los usuarios, y cambios en el tipo de createUser para que asi no necesite un mock falso de avatar desde l front que no teníamos, y ya queda solucionado en ambos lugares.

### Feeling
[//]: <> (Como te sientes con este PR? la solucion que entregas como te hace sentir?)
- [ ] 🤙 Solucion rapida
- [x] 👌 Terminado y listo
- [ ] 🤞 Espero que esto funcione, por favor revisar cuidadosamente

### Cómo probar?
[//]: <> (Pasos necesarios para probar esta funcionalidad)
`npx prisma migrate reset` y a comprobar ese flujo je, crear un user y dirigirse al profile luego de activarlo para ver si si funciona la imagen default de perfil.

### Screenshots (si es aplicable)
[//]: <> (Capturas de pantalla que ayuden a entender que hiciste en este PR)
![image](https://github.com/davidenco88/backend-cab/assets/79395978/42457511-7a3a-4566-b5ac-0cc9f2f9fa7b)

### Scope

- [x] 🐞 Bugfix (non-breaking changes que resuelve un problema
- [ ] 💚 Mejora (non-breaking change que agrega/modifica funcionalidad a una característica existente)
- [ ] ⚡️ Nueva característica/feature (non-breaking change que agrega una nueva característica)
- [ ] ⚠️ Breaking change (cambio que no es compatible con versiones anteriores y/o cambia la funcionalidad actual)
